### PR TITLE
Create class Item

### DIFF
--- a/modules/item.rb
+++ b/modules/item.rb
@@ -13,6 +13,8 @@ class Item
     Date.parse(@published_date).year < Date.today.year - 10
   end
 
+  private :can_be_archived?
+
   def move_to_archive?
     return unless can_be_archived?
 

--- a/modules/item.rb
+++ b/modules/item.rb
@@ -1,0 +1,21 @@
+require 'date'
+
+class Item
+  attr_accessor :published_date, :archived
+
+  def initialize(published_date, archived)
+    @published_date = published_date
+    @archived = archived
+    @id = Random.rand(1..1000)
+  end
+
+  def can_be_archived?
+    Date.parse(@published_date).year < Date.today.year - 10
+  end
+
+  def move_to_archive?
+    return unless can_be_archived?
+
+    true
+  end
+end

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -1,0 +1,27 @@
+require_relative '../modules/item'
+
+RSpec.describe Item do
+  context 'can_be_archived?' do
+    it 'shoud return false' do
+      result = Item.new('2022/01/01', true)
+      expect(result.can_be_archived?).to be false
+    end
+
+    it 'shoud return true' do
+      result = Item.new('2012/01/01', true)
+      expect(result.can_be_archived?).to be true
+    end
+  end
+
+  context 'move_to_archive' do
+    it 'should return true' do
+      result = Item.new('2012/01/01', true)
+      expect(result.move_to_archive?).to be true
+    end
+
+    it 'should return true or false' do
+      result = Item.new('2022/01/01', true)
+      expect(result.move_to_archive?).to be nil
+    end
+  end
+end

--- a/spec/item_spec.rb
+++ b/spec/item_spec.rb
@@ -1,18 +1,6 @@
 require_relative '../modules/item'
 
 RSpec.describe Item do
-  context 'can_be_archived?' do
-    it 'shoud return false' do
-      result = Item.new('2022/01/01', true)
-      expect(result.can_be_archived?).to be false
-    end
-
-    it 'shoud return true' do
-      result = Item.new('2012/01/01', true)
-      expect(result.can_be_archived?).to be true
-    end
-  end
-
   context 'move_to_archive' do
     it 'should return true' do
       result = Item.new('2012/01/01', true)


### PR DESCRIPTION
Hey @DaveZag  @KareemWilson ,

In this particular branch, we : 

- [x] Create Item class in a separate .rb file.
- [ ] All Item class properties visible in the diagram are defined and set up in the constructor method. Exception: properties for the 1-to-many relationships are NOT set in the constructor method. Instead, they have a custom setter method created.
- [x] Add the following methods visible in the diagram
- can_be_archived?() in the Item class
should return true if published_date is older than 10 years.
otherwise, it should return false.
- move_to_archive() in the Item class
should reuse can_be_archived?() method.
should change the archived property to true if the result of the can_be_archived?() method is true.
should do nothing if the result of the can_be_archived?() method is false.